### PR TITLE
Add setting in preference

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("org.jetbrains.intellij") version "1.1.4"
     java
     kotlin("jvm") version "1.5.21"
+    kotlin("plugin.serialization") version "1.5.21"
 }
 
 group = "work.ezura"
@@ -15,6 +16,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation("com.squareup.okhttp3:okhttp:4.9.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }

--- a/src/main/kotlin/Translator.kt
+++ b/src/main/kotlin/Translator.kt
@@ -1,6 +1,7 @@
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.*
 import okhttp3.*
+import settings.AppSettingsState
 import java.io.IOException
 
 class Translator {
@@ -15,11 +16,11 @@ class Translator {
         CoroutineStart.DEFAULT
     ) {
         val client = OkHttpClient()
+        val appClientConfig = AppSettingsState.instance.apiClientConfig
         val headers = Headers.headersOf(
             "Content-Type", "application / x-www-form-urlencoded; charset = UTF-8",
-            // TODO:
-            "X-Naver-Client-Id", "",
-            "X-Naver-Client-Secret", ""
+            "X-Naver-Client-Id", appClientConfig.id,
+            "X-Naver-Client-Secret", appClientConfig.secret
         )
         val requestBody = FormBody.Builder()
             .add("text", text)

--- a/src/main/kotlin/settings/AppSettingsComponent.kt
+++ b/src/main/kotlin/settings/AppSettingsComponent.kt
@@ -1,0 +1,53 @@
+package settings
+
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.FormBuilder
+import javax.swing.BorderFactory
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class AppSettingsComponent {
+    val panel: JPanel
+    private val apiClientTextField = JBTextField()
+    private val apiSecretTextField = JBTextField()
+
+    val preferredFocusedComponent: JComponent
+        get() = apiClientTextField
+
+    var apiClientText: String
+        get() = apiClientTextField.text
+        set(newText) {
+            apiClientTextField.text = newText
+        }
+
+    var apiSecretText: String
+        get() = apiSecretTextField.text
+        set(newText) {
+            apiSecretTextField.text = newText
+        }
+
+    init {
+        // TODO: Add titled border
+        panel = FormBuilder.createFormBuilder()
+            .addComponent(
+                JBLabel("Papago API settings: "),
+                0
+            )
+            .addLabeledComponent(
+                JBLabel("API client ID: "),
+                apiClientTextField,
+                1,
+                false
+            )
+            .addLabeledComponent(
+                JBLabel("API client secret: "),
+                apiSecretTextField,
+                1,
+                false
+            )
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+    }
+}

--- a/src/main/kotlin/settings/AppSettingsComponent.kt
+++ b/src/main/kotlin/settings/AppSettingsComponent.kt
@@ -1,31 +1,27 @@
 package settings
 
-import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
-import javax.swing.BorderFactory
 import javax.swing.JComponent
 import javax.swing.JPanel
 
 class AppSettingsComponent {
     val panel: JPanel
-    private val apiClientTextField = JBTextField()
+    private val apiClientIdTextField = JBTextField()
     private val apiSecretTextField = JBTextField()
 
     val preferredFocusedComponent: JComponent
-        get() = apiClientTextField
+        get() = apiClientIdTextField
 
-    var apiClientText: String
-        get() = apiClientTextField.text
-        set(newText) {
-            apiClientTextField.text = newText
-        }
-
-    var apiSecretText: String
-        get() = apiSecretTextField.text
-        set(newText) {
-            apiSecretTextField.text = newText
+    var apiClientConfig: AppSettingsState.ApiClientConfig
+        get() = AppSettingsState.ApiClientConfig(
+            id = apiClientIdTextField.text,
+            secret = apiSecretTextField.text
+        )
+        set(newValue) {
+            apiClientIdTextField.text = newValue.id
+            apiSecretTextField.text = newValue.secret
         }
 
     init {
@@ -37,7 +33,7 @@ class AppSettingsComponent {
             )
             .addLabeledComponent(
                 JBLabel("API client ID: "),
-                apiClientTextField,
+                apiClientIdTextField,
                 1,
                 false
             )

--- a/src/main/kotlin/settings/AppSettingsConfigurable.kt
+++ b/src/main/kotlin/settings/AppSettingsConfigurable.kt
@@ -8,7 +8,7 @@ class AppSettingsConfigurable : Configurable {
     private var settingsComponent: AppSettingsComponent? = null
 
     @Nls(capitalization = Nls.Capitalization.Title)
-    override fun getDisplayName(): String  = "Plugin: Translation Plugin"
+    override fun getDisplayName(): String  = "Translation Plugin"
 
     override fun getPreferredFocusedComponent(): JComponent =
         settingsComponent!!.preferredFocusedComponent
@@ -20,21 +20,18 @@ class AppSettingsConfigurable : Configurable {
 
     override fun isModified(): Boolean {
         val currentSettings = AppSettingsState.instance
-        // TODO: Data class
-        return !currentSettings.client.equals(settingsComponent!!.apiClientText) ||
-                !currentSettings.secret.equals(settingsComponent!!.apiSecretText)
+        val apiClientConfig = settingsComponent!!.apiClientConfig
+        return currentSettings.apiClientConfig != apiClientConfig
     }
 
     override fun apply() {
-        val settings: AppSettingsState = AppSettingsState.instance
-        settings.client = settingsComponent!!.apiClientText
-        settings.secret = settingsComponent!!.apiSecretText
+        val settings = AppSettingsState.instance
+        settings.apiClientConfig = settingsComponent!!.apiClientConfig
     }
 
     override fun reset() {
-        val settings: AppSettingsState = AppSettingsState.instance
-        settingsComponent!!.apiClientText = settings.client
-        settingsComponent!!.apiSecretText = settings.secret
+        val settings = AppSettingsState.instance
+        settingsComponent!!.apiClientConfig = settings.apiClientConfig
     }
 
     override fun disposeUIResources() {

--- a/src/main/kotlin/settings/AppSettingsConfigurable.kt
+++ b/src/main/kotlin/settings/AppSettingsConfigurable.kt
@@ -1,0 +1,43 @@
+package settings
+
+import com.intellij.openapi.options.Configurable
+import org.jetbrains.annotations.Nls
+import javax.swing.JComponent
+
+class AppSettingsConfigurable : Configurable {
+    private var settingsComponent: AppSettingsComponent? = null
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    override fun getDisplayName(): String  = "Plugin: Translation Plugin"
+
+    override fun getPreferredFocusedComponent(): JComponent =
+        settingsComponent!!.preferredFocusedComponent
+
+    override fun createComponent(): JComponent? {
+        settingsComponent = AppSettingsComponent()
+        return settingsComponent!!.panel
+    }
+
+    override fun isModified(): Boolean {
+        val currentSettings = AppSettingsState.instance
+        // TODO: Data class
+        return !currentSettings.client.equals(settingsComponent!!.apiClientText) ||
+                !currentSettings.secret.equals(settingsComponent!!.apiSecretText)
+    }
+
+    override fun apply() {
+        val settings: AppSettingsState = AppSettingsState.instance
+        settings.client = settingsComponent!!.apiClientText
+        settings.secret = settingsComponent!!.apiSecretText
+    }
+
+    override fun reset() {
+        val settings: AppSettingsState = AppSettingsState.instance
+        settingsComponent!!.apiClientText = settings.client
+        settingsComponent!!.apiSecretText = settings.secret
+    }
+
+    override fun disposeUIResources() {
+        settingsComponent = null
+    }
+}

--- a/src/main/kotlin/settings/AppSettingsState.kt
+++ b/src/main/kotlin/settings/AppSettingsState.kt
@@ -1,0 +1,35 @@
+package settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+@State(
+    name = "settings.AppSettingsState",
+    storages = [Storage("TranslationPluginSettings.xml")]
+)
+class AppSettingsState : PersistentStateComponent<AppSettingsState?> {
+
+//    data class ApiConfig(
+//        var client: String = "",
+//        var secret: String = ""
+//    )
+//
+//    var appConfig: ApiConfig = ApiConfig()
+
+    var client: String = ""
+    var secret: String = ""
+
+    override fun getState(): AppSettingsState = this
+
+    override fun loadState(state: AppSettingsState) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+
+    companion object {
+        val instance: AppSettingsState
+            get() = ApplicationManager.getApplication().getService(AppSettingsState::class.java)
+    }
+}

--- a/src/main/kotlin/settings/AppSettingsState.kt
+++ b/src/main/kotlin/settings/AppSettingsState.kt
@@ -4,7 +4,13 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.Converter
 import com.intellij.util.xmlb.XmlSerializerUtil
+import com.intellij.util.xmlb.annotations.OptionTag
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 @State(
     name = "settings.AppSettingsState",
@@ -12,24 +18,31 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 )
 class AppSettingsState : PersistentStateComponent<AppSettingsState?> {
 
-//    data class ApiConfig(
-//        var client: String = "",
-//        var secret: String = ""
-//    )
-//
-//    var appConfig: ApiConfig = ApiConfig()
+    @Serializable
+    data class ApiClientConfig(
+        var id: String = "",
+        var secret: String = ""
+    )
 
-    var client: String = ""
-    var secret: String = ""
+    class ApiConfigConverter : Converter<ApiClientConfig?>() {
+        override fun fromString(value: String): ApiClientConfig =
+            Json.decodeFromString(value)
 
-    override fun getState(): AppSettingsState = this
-
-    override fun loadState(state: AppSettingsState) {
-        XmlSerializerUtil.copyBean(state, this)
+        override fun toString(value: ApiClientConfig): String =
+            Json.encodeToString(value)
     }
 
     companion object {
         val instance: AppSettingsState
             get() = ApplicationManager.getApplication().getService(AppSettingsState::class.java)
+    }
+
+    @OptionTag(converter = ApiConfigConverter::class)
+    var apiClientConfig = ApiClientConfig()
+
+    override fun getState(): AppSettingsState = this
+
+    override fun loadState(state: AppSettingsState) {
+        XmlSerializerUtil.copyBean(state, this)
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,7 +13,15 @@
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <!-- Add your extensions here -->
+        <applicationService
+                serviceImplementation="settings.AppSettingsState"
+        />
+        <applicationConfigurable
+                parentId="tools"
+                instance="settings.AppSettingsConfigurable"
+                id="work.ezura.intellij.plugin.cinfigure.api"
+                displayName="Translation Plugin Settings"
+        />
     </extensions>
 
     <actions>


### PR DESCRIPTION
# What
User can set parameters of Papago client ID and secret.
<img width="1094" alt="スクリーンショット 2021-07-25 19 47 40" src="https://user-images.githubusercontent.com/2020337/126896580-2c250091-3d8d-45a2-9c4d-4c25d4571c88.png">

# References
* [Settings Guide](https://plugins.jetbrains.com/docs/intellij/settings-guide.html)
* [Persisting State of Components](https://plugins.jetbrains.com/docs/intellij/persisting-state-of-components.html)
* [Settings Tutorial](https://plugins.jetbrains.com/docs/intellij/settings-tutorial.html)
* [papago API document](https://developers.naver.com/docs/papago/papago-detectlangs-overview.md)
* [OkHttp](https://www.baeldung.com/guide-to-okhttp)
* [Serialization](https://kotlinlang.org/docs/serialization.html)

# Screenshots
<img width="513" alt="スクリーンショット 2021-07-25 19 47 12" src="https://user-images.githubusercontent.com/2020337/126896587-6f06404d-9372-4001-8f78-fdc5a6e69a83.png">